### PR TITLE
Use Animated.loop and avoid callback leak

### DIFF
--- a/src/PlaceholderContainer.js
+++ b/src/PlaceholderContainer.js
@@ -75,6 +75,11 @@ export default class PlaceholderContainer extends Component {
         !replace ? this.setState({ Component }) : this._replacePlaceholders();
       });
   }
+
+  componentWillUnmount(): void {
+    this.position.stopAnimation();
+  }
+
   render(): React.Element<*> {
     const { style, elements, animatedComponent, children } = this.props;
     const { Component, isAnimatedComponentMeasured } = this.state;

--- a/src/PlaceholderContainer.js
+++ b/src/PlaceholderContainer.js
@@ -101,27 +101,27 @@ export default class PlaceholderContainer extends Component {
     );
   }
 
-  _triggerAnimation = (cb: Function): void => {
+  _triggerAnimation = (): void => {
     const { duration, delay } = this.props;
     const { startPosition, stopPosition } = this.state;
-    Animated.sequence([
+    Animated.loop(Animated.sequence([
       Animated.timing(this.position, {
         toValue: stopPosition || screenWidth,
-        duration: duration, 
+        duration: duration,
         useNativeDriver: true
       }),
       Animated.timing(this.position, {
         toValue: startPosition || 0,
         duration: 0,
-        delay: delay || 0, 
+        delay: delay || 0,
         useNativeDriver: true
       })
-    ]).start(cb);
+    ])).start();
   };
 
   _startAndRepeat = (): void => {
     const { Component } = this.state;
-    !Component && this._triggerAnimation(this._startAndRepeat);
+    !Component && this._triggerAnimation();
   };
 
   _measureView = (viewName: string, event: Object): void => {


### PR DESCRIPTION
While using detox, I opened https://github.com/wix/detox/issues/390 and I found that:

```js
]).start(cb);
```

Was executing the callback recursively (for the loop) even when the component was unmounted. With `Animated.loop` this should be handle and we do not need extra variables.