### PR TITLE
Set interaction to false

### DIFF
--- a/src/PlaceholderContainer.js
+++ b/src/PlaceholderContainer.js
@@ -113,13 +113,15 @@ export default class PlaceholderContainer extends Component {
       Animated.timing(this.position, {
         toValue: stopPosition || screenWidth,
         duration: duration,
-        useNativeDriver: true
+        useNativeDriver: true,
+        isInteraction: false
       }),
       Animated.timing(this.position, {
         toValue: startPosition || 0,
         duration: 0,
         delay: delay || 0,
-        useNativeDriver: true
+        useNativeDriver: true,
+        isInteraction: false
       })
     ])).start();
   };


### PR DESCRIPTION
I think the animation for this placeholder loading is not an interaction and by default the isInteraction is `true`. This lead to a case when we using some thing like this

`InteractionManager.runAfterInteractions(() => {
// do some stuff
    });`

And the function never get call until the placeholder-loading is un-mount.